### PR TITLE
Use pipenv inside tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .tox
 .cache
+Pipfile.lock

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,0 @@
-PyYAML
-pytest

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,10 @@ envlist = py36
 skipsdist = true
 
 [testenv]
-deps = -rrequirements-dev.txt
-commands = python tests.py
+passenv = HOME
+deps = pipenv
+commands =
+    pipenv install --dev
+    python tests.py
+    pipenv check
+    - pipenv check --style .


### PR DESCRIPTION
Instead of using the old requirements.txt format for installing
dependencies, just use pipenv. The requirements-dev.txt file can now be
removed.
Adds `pipenv check` to the commands to run.