### PR TITLE
Auto-format code

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -7,17 +7,25 @@ import pytest
 import safeyaml
 
 SMOKE_TESTS = {
-    """ [0] """:            [0],
-    """ [1.2] """:          [1.2],
-    """ [-3.4] """:         [-3.4],
-    """ [+5.6] """:         [+5.6],
-    """ "test": 1 """:      {'test':1},
-    """ x: 'test' """:      {'x':'test'},
-    """ [1 ,2,3] """:       [1,2,3],
-    """ [1,2,3,] """:       [1,2,3],
-    """ {"a":1} """:        {'a':1},
-    """ {'b':2,} """:       {'b':2},
-    """ [1  #foo\n] """:    [1],
+    """ [0] """: [0],
+    """ [1.2] """: [1.2],
+    """ [-3.4] """: [-3.4],
+    """ [+5.6] """: [+5.6],
+    """ "test": 1 """: {
+        'test': 1
+    },
+    """ x: 'test' """: {
+        'x': 'test'
+    },
+    """ [1 ,2,3] """: [1, 2, 3],
+    """ [1,2,3,] """: [1, 2, 3],
+    """ {"a":1} """: {
+        'a': 1
+    },
+    """ {'b':2,} """: {
+        'b': 2
+    },
+    """ [1  #foo\n] """: [1],
 }
 
 
@@ -70,15 +78,15 @@ def check_file(path, validate=False, fix=False):
         if validate:
             try:
                 ref_obj = yaml.load(contents)
-            except:
-                raise Exception("input isn't valid YAML: {}".format(contents))
+            except yaml.YAMLError:
+                raise Exception("input isn't valid YAML:\n{}".format(contents))
 
             assert obj == ref_obj
 
             try:
                 parsed_output = yaml.load(output)
-            except Exception as e:
-                raise Exception("output isn't valid YAML: {}".format(output))
+            except yaml.YAMLError:
+                raise Exception("output isn't valid YAML:\n{}".format(output))
 
             assert parsed_output == ref_obj
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,11 @@ deps = pipenv
 commands =
     pipenv install --dev
     python tests.py
-    pipenv check
-    - pipenv check --style .
+    pipenv check --style .
+
+[testenv:format]
+deps = yapf
+commands = yapf -e '*/.tox/*' -ri .
+
+[flake8]
+ignore = E251,E501


### PR DESCRIPTION
Used `yapf` to auto-format the code and performed a couple of manual fixes.

`tox` now runs `pipenv check --style` and complains if it fails. A couple of style rules have been disabled, because `yapf` seems to apply `pep8` a little loosely.

You can auto-format the code with `tox -e format`.